### PR TITLE
Fix typo in example

### DIFF
--- a/pkg/error/example_newfactory_test.go
+++ b/pkg/error/example_newfactory_test.go
@@ -35,7 +35,7 @@ message = "cannot determine content type for archival object"
 		panic(err)
 	}
 
-	factoryErr := errorFactory.NewError("xGOCFL::1", "(add)ing to GOCFL archive", fmt.Errorf("disk is readonly"))
+	factoryErr := errorFactory.NewError("GOCFL::1", "(add)ing to GOCFL archive", fmt.Errorf("disk is readonly"))
 	if factoryErr.ID == "IDUnknownError" {
 		// error could not be retrieved from the factory.
 		// we can handle it differently here, or fall through


### PR DESCRIPTION
A small typo to help improve interactivity in the example.

It might also be a good idea to change the name of the library. Currently error conflicts with an in-built. The primary impact is that the library will always be import with an alias. In the example use-case in the docs the example is not interactive, we get an error:

![image](https://github.com/user-attachments/assets/50e23a9e-5f11-4b03-bc8d-56a35f83a00d)

```
./prog.go:26:21: error.LoadTOMLData undefined (type error has no field or method LoadTOMLData)
./prog.go:30:24: error.NewFactory undefined (type error has no field or method NewFactory)
```
